### PR TITLE
Replace 'and' by 'or' to ensure that both parameters are not empty

### DIFF
--- a/aylienapiclient/textapi.py
+++ b/aylienapiclient/textapi.py
@@ -44,7 +44,7 @@ class Client(object):
     MissingCredentialsError: If applicationId or applicationKey are empty
   """
   def __init__(self, applicationId, applicationKey, useHttps=True):
-    if not applicationId and not applicationKey:
+    if not applicationId or not applicationKey:
       raise MissingCredentialsError('Invalid Application ID or Application Key.')
 
     self.applicationId = applicationId

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -8,6 +8,7 @@ import inspect
 from nose.tools import eq_
 from nose.tools import ok_
 from nose.tools import raises
+from nose.tools import assert_raises
 
 from aylienapiclient import http
 from aylienapiclient import textapi
@@ -54,9 +55,10 @@ def check_invalid_auth(endpoint, input):
   method = getattr(client, endpoint)
   method(input)
 
-@raises(MissingCredentialsError)
 def test_raises_missing_credentials_error():
-  client = textapi.Client("", "")
+  assert_raises(MissingCredentialsError, textapi.Client, "app_id", "")
+  assert_raises(MissingCredentialsError, textapi.Client, "", "app_key")
+  assert_raises(MissingCredentialsError, textapi.Client, "", "")
 
 def test_empty_params_generator():
   for e in endpoints:


### PR DESCRIPTION
To ensure that both parameters are not empty, as stated on above docstring

```
Raises:
    MissingCredentialsError: If applicationId or applicationKey are empty
```